### PR TITLE
Fix Ragas AnswerRelevancy scoring

### DIFF
--- a/backend/core/evaluation.py
+++ b/backend/core/evaluation.py
@@ -69,7 +69,7 @@ Respond in JSON format:
         """
         prompt = self._get_sub_prompt(main_req_name, sub_req_name, source, regulatory_reference, associated_chunks)
         # Simplify the RAGAS question to avoid redundancy and improve semantic matching (Relevancy)
-        ragas_question = f"Does the document provide evidence of compliance for the '{main_req_name}' sub-requirement '{sub_req_name}' ({source})?"
+        ragas_question = f"What is the detailed rationale and summary of compliance for the '{main_req_name}' sub-requirement '{sub_req_name}' ({source})?"
         response = self.llm.invoke(prompt).content.strip()
         try:
             cleaned = response.replace("```json", "").replace("```", "").strip()

--- a/evaluation/case_evaluation.py
+++ b/evaluation/case_evaluation.py
@@ -58,7 +58,7 @@ def evaluate_single_case(
             sub_name = sub.get("Reference", "")
             source = sub.get("Source", "")
 
-            ragas_question = f"Does the document provide evidence of compliance for the '{req_name}' sub-requirement '{sub_name}' ({source})?"
+            ragas_question = f"What is the detailed rationale and summary of compliance for the '{req_name}' sub-requirement '{sub_name}' ({source})?"
 
             contexts = sub.get("Contexts", [])
 

--- a/evaluation/metrics.py
+++ b/evaluation/metrics.py
@@ -110,7 +110,7 @@ def compute_ragas_metrics(samples: List[Dict[str, Any]]) -> Dict[str, Optional[f
 
         ragas_dataset = Dataset.from_list([
             {
-                "question": f"Evaluate compliance for: {sample['question']}",
+                "question": sample["question"],
                 "answer": sample["answer"],
                 "contexts": sample["contexts"],
                 "ground_truth": sample.get("ground_truth", ""),


### PR DESCRIPTION
Fixes the RAGAS Answer Relevancy metric returning 0.0.

- Changed `ragas_question` in `backend/core/evaluation.py` to be open-ended.
- Changed `ragas_question` in `evaluation/case_evaluation.py` to be open-ended.
- Removed the "Evaluate compliance for: " prefix in `evaluation/metrics.py`.

---
*PR created automatically by Jules for task [215618205480701792](https://jules.google.com/task/215618205480701792) started by @davidedm26*