### PR TITLE
Improve Ragas AnswerRelevancy metric

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -60,3 +60,4 @@ data/debug/*
 # Metrics
 metrics/**
 metrics/ragas_records.json
+mlflow.db

--- a/backend/core/evaluation.py
+++ b/backend/core/evaluation.py
@@ -70,7 +70,7 @@ Respond in JSON format:
         """
         prompt = self._get_sub_prompt(main_req_name, sub_req_name, source, regulatory_reference, associated_chunks)
         # Question format that matches analytical response style
-        ragas_question = f"What is the compliance status of sub-requirement '{sub_req_name}' from {source}?"
+        ragas_question = f"Is the provided document compliant with the sub-requirement '{sub_req_name}' from {source}?"
 
         response = self.llm.invoke(prompt).content.strip()
         try:

--- a/evaluation/case_evaluation.py
+++ b/evaluation/case_evaluation.py
@@ -49,9 +49,10 @@ def evaluate_single_case(
     for pred in predictions:
         sub_reqs = pred.get("SubRequirements") or []
         for sub in sub_reqs:
-            # Use rationale for both faithfulness and relevancy
-            # The rationale provides detailed, grounded analysis
-            combined_answer = sub.get('Rationale', '')
+            # Reconstruct combined_answer from both Rationale and Auditor_Notes to improve relevancy
+            rationale = sub.get('Rationale', '')
+            auditor_notes = sub.get('Auditor_Notes', '')
+            combined_answer = f"{rationale}\n\nSummary: {auditor_notes}"
 
             # The prompt/question logic needs to be reconstructed or we rely on contexts
             # Since we didn't save the explicit ragas_question in SubRequirementReport,
@@ -61,8 +62,7 @@ def evaluate_single_case(
             source = sub.get("Source", "")
 
             # Question format that matches analytical response style
-            ragas_question = f"What is the compliance status of sub-requirement '{sub_name}' from {source}?"
-
+            ragas_question = f"Is the provided document compliant with the sub-requirement '{sub_name}' from {source}?"
 
             contexts = sub.get("Contexts", [])
 


### PR DESCRIPTION
Refactored the question and answer formats used for Ragas evaluation to improve the `AnswerRelevancy` metric. The `ragas_question` format was changed to a direct polar boolean question, and the `combined_answer` was reconstructed to include both the Rationale and the Auditor_Notes summary. `.gitignore` was also updated.

---
*PR created automatically by Jules for task [15319942777189328762](https://jules.google.com/task/15319942777189328762) started by @davidedm26*