### PR TITLE
feat: Add sub-requirements toggle list to frontend UI

### DIFF
--- a/backend/app.py
+++ b/backend/app.py
@@ -10,10 +10,10 @@ from fastapi.middleware.cors import CORSMiddleware
 
 try:
     from . import rag_engine
-    from .rag_engine import AuditResponse, AuditResponseAPI, RequirementReportAPI
+    from .rag_engine import AuditResponse, AuditResponseAPI, RequirementReportAPI, SubRequirementReportAPI
 except ImportError:  # Fallback when running as script (python app.py)
     import rag_engine  # type: ignore
-    from rag_engine import AuditResponse, AuditResponseAPI, RequirementReportAPI  # type: ignore
+    from rag_engine import AuditResponse, AuditResponseAPI, RequirementReportAPI, SubRequirementReportAPI  # type: ignore
 
 load_dotenv() # Load environment variables from .env file
 
@@ -63,7 +63,7 @@ async def audit(document_text: str = Body(..., embed=True)): # Audit endpoint
             debug_dump_path=DEBUG_DUMP_PATH,
         )
         
-        # Convert to lightweight API response (exclude Prompt and SubRequirements)
+        # Convert to lightweight API response (exclude Prompt, keep SubRequirements)
         api_requirements = [
             RequirementReportAPI(
                 Requirement_ID=req.Requirement_ID,
@@ -71,7 +71,18 @@ async def audit(document_text: str = Body(..., embed=True)): # Audit endpoint
                 Requirement_Name=req.Requirement_Name,
                 Score=req.Score,
                 Rationale=req.Rationale,
-                Auditor_Notes=req.Auditor_Notes
+                Auditor_Notes=req.Auditor_Notes,
+                SubRequirements=[
+                    SubRequirementReportAPI(
+                        Reference=sub.Reference,
+                        Source=sub.Source,
+                        Score=sub.Score,
+                        Rationale=sub.Rationale,
+                        Auditor_Notes=sub.Auditor_Notes,
+                        Contexts=sub.Contexts
+                    )
+                    for sub in req.SubRequirements
+                ]
             )
             for req in full_response.requirements
         ]

--- a/backend/rag_engine.py
+++ b/backend/rag_engine.py
@@ -64,6 +64,14 @@ class RequirementReport(BaseModel):
 
 
 # Lightweight model for API responses (excludes verbose fields)
+class SubRequirementReportAPI(BaseModel):
+    Reference: str
+    Source: str
+    Score: RequirementScore
+    Rationale: str
+    Auditor_Notes: str
+    Contexts: List[str]
+
 class RequirementReportAPI(BaseModel):
     Requirement_ID: str
     Requirement_Category: str
@@ -71,6 +79,7 @@ class RequirementReportAPI(BaseModel):
     Score: RequirementScore
     Rationale: Optional[str] = None
     Auditor_Notes: str
+    SubRequirements: List[SubRequirementReportAPI] = []
 
 
 class AuditResponse(BaseModel):

--- a/frontend/pages/Audit_Compliance.py
+++ b/frontend/pages/Audit_Compliance.py
@@ -398,11 +398,13 @@ if analyze_btn and doc_text:
                     r_id = item.get("Requirement_ID", "N/A")
                     r_notes = item.get("Auditor_Notes", "No notes available.")
                     r_rationale = item.get("Rationale", "No rationale provided.")
+                    r_sub_reqs = item.get("SubRequirements", [])
                     score = item.get("Score", 0) 
                     
                     processed_reqs.append({
                         "name": r_name, "id": r_id, "score_display": f"{score}/5", 
-                        "progress": score / 5.0, "notes": r_notes, "rationale": r_rationale
+                        "progress": score / 5.0, "notes": r_notes, "rationale": r_rationale,
+                        "sub_requirements": r_sub_reqs
                     })
                     total += score
                     maxim += 5
@@ -598,6 +600,16 @@ if st.session_state.audit_results is not None:
 
                         st.caption("Rationale")
                         st.text(req.get("rationale", "No rationale provided."))
+
+                        sub_reqs = req.get("sub_requirements", [])
+                        if sub_reqs:
+                            with st.expander("Show Sub-Requirements Details"):
+                                for sub in sub_reqs:
+                                    st.markdown(f"#### {sub.get('Source', 'N/A')} - {sub.get('Reference', 'N/A')}")
+                                    st.markdown(f"**Score:** {sub.get('Score', 'N/A')}")
+                                    st.markdown(f"**Notes:** {sub.get('Auditor_Notes', 'N/A')}")
+                                    st.markdown(f"**Rationale:** {sub.get('Rationale', 'N/A')}")
+                                    st.markdown("---")
 elif analyze_btn and not doc_text:
     st.warning("Please upload a file or paste text.")
 


### PR DESCRIPTION
Resolves the user request to show the subrequirement report directly on the frontend UI by updating the API payload logic and rendering a toggle list (expander).

- Created `SubRequirementReportAPI` model and added `SubRequirements: List[SubRequirementReportAPI]` to `RequirementReportAPI` in `backend/rag_engine.py`
- Updated `/audit` endpoint mapping in `backend/app.py` to maintain SubRequirement structures while still stripping large prompt contexts
- Modified parsing loops in `frontend/pages/Audit_Compliance.py` to extract `sub_requirements` from the backend JSON response
- Rendered sub-requirements within an `st.expander` toggle inside the frontend UI layout

---
*PR created automatically by Jules for task [15587741024404621640](https://jules.google.com/task/15587741024404621640) started by @davidedm26*